### PR TITLE
Truncate tailing incomplete func calls

### DIFF
--- a/mldaikon/config/config.py
+++ b/mldaikon/config/config.py
@@ -26,3 +26,4 @@ NOT_USE_AS_CLAUSE_FIELDS = ["func_call_id", "process_id", "thread_id", "time", "
 VAR_ATTR_PREFIX = "attributes."
 
 CONST_CLAUSE_NUM_VALUES_THRESHOLD = 1  # FIXME: ad-hoc
+INCOMPLETE_FUNC_CALL_SECONDS_TO_OUTERMOST_POST = 0.001  # only truncate the incomplete function call if it is no earlier than 1ms to the outermost function call's post event


### PR DESCRIPTION
Fixes https://github.com/OrderLab/ml-daikon/issues/31, and pass the `correctness_check_api_trace.py` test.

Incomplete function calls are detected by first grouping the trace w.r.t `func_call_id`, and find `func_call_id`s with only one trace record.

**This fix relies on the uniqueness of `func_call_id` for each function call. Changing `func_call_id` behavior would break this PR**

After detection, incomplete func calls will be truncated if and only if it is no earlier than the outermost function call's `post` event (1ms error allowed, see `INCOMPLETE_FUNC_CALL_SECONDS_TO_OUTERMOST_POST` in `config.py`). In other cases, an exception will still be raised.

This truncation step is performed at trace loading time. Enabling the truncation adds a mild 2% slow down on the 84911 API trace (around 60 MB, 300k loc).

<img width="806" alt="image" src="https://github.com/OrderLab/ml-daikon/assets/31838999/7115ed68-c00e-4d83-879f-fbaaf734e851">