### PR TITLE
e2e: update automated fixed & buggy pipeline setup for ml-issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,4 @@ Deepspeed/
 !config.json
 # local dummy files from yijun's branch
 84911_100_proxy_trace
+/lightning-thunder

--- a/example_pipelines/INSTALL_CONFIG
+++ b/example_pipelines/INSTALL_CONFIG
@@ -1,0 +1,1 @@
+third_party_libs_dir=.

--- a/mldaikon/e2e/config.py
+++ b/mldaikon/e2e/config.py
@@ -4,7 +4,7 @@ current_dir = os.path.dirname(os.path.abspath(__file__))
 modules_to_instrument = ["megatron", "deepspeed", "torch"]
 proxy_module = "model"
 # should be current_dir + '../../example_pipelines'
-EXAMPLE_PIPELINES_DIR = os.path.join(current_dir, "../../example_pipelines")
+EXAMPLE_PIPELINES_DIR = os.path.join(current_dir, "../../machine-learning-issues")
 input_env = {
     "PYTORCH_JIT": "0"
 }  # should appear at the start of the mldaikon.collect_trace running command

--- a/mldaikon/e2e/runner.py
+++ b/mldaikon/e2e/runner.py
@@ -121,6 +121,8 @@ def run_e2e(
     infer_engine_script_args: list[str] = [
         "-m",
         "mldaikon.infer_engine",
+        "-o",
+        f"{output_dir}/invariants.json",
         "-t",
         # " ".join(processed_proxy_files),
         # " ".join(API_trace_files),

--- a/mldaikon/e2e_runner.py
+++ b/mldaikon/e2e_runner.py
@@ -99,7 +99,17 @@ if __name__ == "__main__":
     if not os.path.isfile(input_program):
         input_program_dir = os.path.join(example_pipelines_dir, script_name)
         input_program_list = find_files(input_program_dir, prefix="", suffix=".py")
+        # input program should not include _ml_daikon at the beginning of the name
+        # e.g. '../../example_pipelines/LT-725/_ml_daikon_LT725.py' is not a valid input program
+        input_program_list = [
+            file
+            for file in input_program_list
+            if not os.path.basename(file).startswith("_ml_daikon")
+        ]
         input_bash_script_list = find_files(input_program_dir, prefix="", suffix=".sh")
+        input_bash_script_list = [
+            file for file in input_bash_script_list if not file.endswith("install.sh")
+        ]
         input_config_file = os.path.join(input_program_dir, "config.json")
         print(f"input_config_file: {input_config_file}")
         if not os.path.exists(input_config_file):


### PR DESCRIPTION
**This PR established fixed & buggy pipeline setup for machine learning issues repo.**

For the following bug collection, I suggest that we can put them into the `machine-learning-issues` repo (put it right under the ml-daikon repo for simplicity) and maintain a `install.sh` for each input pipeline cases.

The install.sh maintains four operations:
- install: setup the conda venv and install the input pipeline from source (cloned github repo)
- build buggy/fixed: check out to the buggy/fixed versions of the github repo (now support checkout to specific commit and pr)
- uninstall: remove the conda venv and any downloaded input pipelines.

For example, to create a buggy venv for LT-725, simply run:

```sh
sh sh ./example_pipelines/LT-725/install.sh build_buggy
```

This would automatically create a venv called `${venv_name}` (lightning-thunder), install the repo under the `./{pkg_name}` (lightning_thunder), install the mldaikon package inside the venv and automatically checkout to the buggy commit. 

I'll create a template for setting up the install.sh for other input pipelines. There is only a few steps for customization.

After setting up the input pipeline and environment, we could directly use this e2e_runner to get the invariant from the correct/buggy versions respectively. Use the command as follows:

```python
python -m mldaikon.e2e_runner -s <folder name inside the example_pipelines>
```
