### PR TITLE
proxy: support bookkeeping for unproxied object

### DIFF
--- a/mldaikon/proxy_wrapper/proxy.py
+++ b/mldaikon/proxy_wrapper/proxy.py
@@ -24,74 +24,13 @@ from mldaikon.proxy_wrapper.dumper import (
 from mldaikon.proxy_wrapper.dumper import json_dumper as dumper
 from mldaikon.proxy_wrapper.proxy_basics import unproxy_arg
 from mldaikon.proxy_wrapper.proxy_handler import PROXY_SUPPORT_OBJ_TYPES
+from mldaikon.proxy_wrapper.proxy_registry import global_registry
 from mldaikon.proxy_wrapper.utils import print_debug
 from mldaikon.utils import get_timestamp_ns, typename
 
 
 def get_line(filename, lineno):
     return linecache.getline(filename, lineno).strip()
-
-
-class RegistryEntry:
-    """A class to store the proxy object and its associated metadata"""
-
-    def __init__(self, proxy: "Proxy", stale: bool):
-        self.proxy = proxy
-        self.stale = stale
-
-
-class ProxyRegistry:
-    """A helper class managing all proxy variables being tracked and allow for controlled dumps of
-    the variable states.
-
-    A variable is uniquely identified by its "name"
-    """
-
-    def __init__(self):
-        self.registry: dict[str, RegistryEntry] = {}
-        self.registry_lock = threading.Lock()
-
-    def add_var(self, var: "Proxy", var_name: str):
-        """Add a new proxy variable to the registry"""
-        with self.registry_lock:
-            self.registry[var_name] = RegistryEntry(proxy=var, stale=False)
-
-    def dump_sample(self, dump_loc=None):
-        """A complete dump of all present proxy objects
-
-        Calling this API mark all proxy objects as stale which
-        will affect the `dump_only_modified` API.
-        """
-        with self.registry_lock:
-            for var_name, entry in self.registry.items():
-                entry.stale = True
-                entry.proxy.dump_trace("sample", dump_loc=dump_loc)
-
-    def dump_only_modified(self, dump_loc=None):
-        """Dump only the proxy variables that might be modified since last dump
-
-        ** This is a middle ground between blindly dump everything everytime v.s. fully-accurate delta dumping **
-        fully-accuracy dumping is hard as for each "modifications" to the variable, you will need to compare
-        the new state v.s. the old state to ensure the state has actually changed, which introduces great overhead.
-
-        This function implements delta dumping but does not guarantee two consecutive dumps will be different,
-        we only guarantee that between two dumps there has been attempts (e.g. through __setattr__ or observer)
-        to modify the variable.
-
-
-        Side effects:
-        when calling the function, all dumped proxy vars will be marked as stale and will not be dumped next time
-        unless there are new modification attempts to t
-        """
-        with self.registry_lock:
-            for var_name, entry in self.registry.items():
-                if entry.stale:
-                    entry.stale = False
-                    entry.proxy.dump_trace("selective-sample", dump_loc=dump_loc)
-
-
-# Global dictionary to store registered objects
-global_registry = ProxyRegistry()
 
 
 def proxy_handler(
@@ -170,6 +109,7 @@ class Proxy:
             parameter = Proxy(
                 parameter, var_name=parent_name + name, from_iter=from_iter
             )
+            parameter.register_object()
             module._parameters[name] = parameter
 
     @staticmethod
@@ -193,6 +133,9 @@ class Proxy:
 
     def register_object(self):
         global_registry.add_var(self, self.__dict__["var_name"])
+
+    def register_unproxied_object(self, _obj):
+        global_registry.add_unproxied_obj(self.__dict__["var_name"], _obj)
 
     def dump_trace(
         self,

--- a/mldaikon/proxy_wrapper/proxy_config.py
+++ b/mldaikon/proxy_wrapper/proxy_config.py
@@ -1,5 +1,6 @@
 proxy_log_dir = "proxy_log.json"  # FIXME: ad-hoc
 proxy_update_limit = 0
+add_obj_to_registry = True
 debug_mode = False
 
 delta_dump_config = {

--- a/mldaikon/proxy_wrapper/proxy_registry.py
+++ b/mldaikon/proxy_wrapper/proxy_registry.py
@@ -1,0 +1,81 @@
+import threading
+from typing import TYPE_CHECKING
+
+from mldaikon.proxy_wrapper import proxy_config
+
+if TYPE_CHECKING:
+    from mldaikon.proxy_wrapper.proxy import Proxy
+
+
+class RegistryEntry:
+    """A class to store the proxy object and its associated metadata"""
+
+    def __init__(self, proxy: "Proxy", stale: bool, _obj=None):
+        self.proxy = proxy
+        self.stale = stale
+        self._obj = _obj
+
+
+class ProxyRegistry:
+    """A helper class managing all proxy variables being tracked and allow for controlled dumps of
+    the variable states.
+
+    A variable is uniquely identified by its "name"
+    """
+
+    def __init__(self):
+        self.registry: dict[str, RegistryEntry] = {}
+        self.registry_lock = threading.Lock()
+
+    def add_var(self, var: "Proxy", var_name: str):
+        """Add a new proxy variable to the registry"""
+        with self.registry_lock:
+            self.registry[var_name] = RegistryEntry(proxy=var, stale=False)
+
+    def add_unproxied_obj(self, var_name: str, _obj):
+        """Add the unproxied object to the proxy variable"""
+        with self.registry_lock:
+            self.registry[var_name]._obj = _obj
+
+    def access_obj(self, var_name: str):
+        """Access the object of the proxy variable"""
+        if proxy_config.add_obj_to_registry:
+            with self.registry_lock:
+                return self.registry[var_name]._obj
+
+    def dump_sample(self, dump_loc=None):
+        """A complete dump of all present proxy objects
+
+        Calling this API mark all proxy objects as stale which
+        will affect the `dump_only_modified` API.
+        """
+        with self.registry_lock:
+            for var_name, entry in self.registry.items():
+                entry.stale = True
+                entry.proxy.dump_trace("sample", dump_loc=dump_loc)
+
+    def dump_only_modified(self, dump_loc=None):
+        """Dump only the proxy variables that might be modified since last dump
+
+        ** This is a middle ground between blindly dump everything everytime v.s. fully-accurate delta dumping **
+        fully-accuracy dumping is hard as for each "modifications" to the variable, you will need to compare
+        the new state v.s. the old state to ensure the state has actually changed, which introduces great overhead.
+
+        This function implements delta dumping but does not guarantee two consecutive dumps will be different,
+        we only guarantee that between two dumps there has been attempts (e.g. through __setattr__ or observer)
+        to modify the variable.
+
+
+        Side effects:
+        when calling the function, all dumped proxy vars will be marked as stale and will not be dumped next time
+        unless there are new modification attempts to t
+        """
+        with self.registry_lock:
+            for var_name, entry in self.registry.items():
+                if entry.stale:
+                    entry.stale = False
+                    entry.proxy.dump_trace("selective-sample", dump_loc=dump_loc)
+
+
+# Global dictionary to store registered objects
+global_registry = ProxyRegistry()


### PR DESCRIPTION
@Essoz I've added a book-keeping for the unproxied object so one proxied object does not need to be unproxied multiple times. It seems reducing the overhead a lot. Could you validate the result on your side?

I also moved the proxy_registry out to a separate file for code clarity