### PR TITLE
Remove unproxy for built-in APIs

### DIFF
--- a/mldaikon/instrumentor/tracer.py
+++ b/mldaikon/instrumentor/tracer.py
@@ -29,7 +29,7 @@ from mldaikon.instrumentor.replace_functions import (
     funcs_to_be_replaced,
     is_funcs_to_be_unproxied,
 )
-from mldaikon.proxy_wrapper.proxy_basics import is_proxied, unproxy_func
+from mldaikon.proxy_wrapper.proxy_basics import is_proxied
 from mldaikon.proxy_wrapper.proxy_config import enable_C_level_observer
 from mldaikon.proxy_wrapper.proxy_registry import get_global_registry
 from mldaikon.utils import get_timestamp_ns, get_unique_id, typename
@@ -261,15 +261,16 @@ def global_wrapper(
                 add_observer_to_func,  # import here to avoid circular import
             )
 
-            original_function = add_observer_to_func(original_function, unproxy=True)
+            original_function = add_observer_to_func(original_function, unproxy=False)
         elif is_funcs_to_be_unproxied(original_function):
-            original_function = unproxy_func(
-                original_function, inspect_torch_module=True
-            )
+            # original_function = unproxy_func(
+            #     original_function, inspect_torch_module=True
+            # )
+            pass
         elif is_builtin:
             # proxy objects being passed to backend will cause seg fault: TODO: replace with unproxy func
-            original_function = unproxy_func(original_function)
-
+            # original_function = unproxy_func(original_function)
+            pass
     try:
         if COLLECT_OVERHEAD_METRICS:
             ORIG_ENTER_PERF_TIME = time.perf_counter()
@@ -407,8 +408,8 @@ def core_wrapper(original_function, is_builtin, handle_proxy, *args, **kwargs):
     if DISABLE_WRAPPER:
         return original_function(*args, **kwargs)
 
-    if handle_proxy and is_builtin:
-        original_function = unproxy_func(original_function)
+    # if handle_proxy and is_builtin:
+    #     original_function = unproxy_func(original_function)
     return original_function(*args, **kwargs)
 
 


### PR DESCRIPTION
**Context:**

We needed to apply a `unproxy` wrapper to every built-in API as passing `Proxy` objects into the backend causes segmentation fault.

However, this `unproxy` step is not very efficient as it requires iterating and type-checking every argument every time a low-level (presumably also a very frequently-called) API is being invoked, leading to performance overheads.

Also, generally we want to reduce number of APIs instrumented to (1) lower the overhead & (2) reduce the intrusiveness of our instrumentation.

**Why:**
The `segmentation fault` issue has been resolved by #115 which uses `__torch_function__` to automatically unproxy objects when a Proxy object is being dispatched.

**TODOs:**
- [ ] Remove all steps to add unproxy wrappers in `global_wrapper` except when adding observers.
- [ ] Remove `core_wrapper` completely.
- [ ] Conduct a new round of overhead experiments to justify the change.